### PR TITLE
Get code to compile on nim devel (fixes #1)

### DIFF
--- a/emerald/html5.nim
+++ b/emerald/html5.nim
@@ -269,7 +269,7 @@ proc html5tags*(): PTagList {.compileTime, tagdef.} =
     script:
         content_categories = (metadata_content, flow_content, phrasing_content)
         permitted_content  = text_content
-        optional_attrs     = (async, src, `type`, defer)
+        optional_attrs     = (async, src, `type`, `defer`)
     select:
         content_categories = (flow_content, phrasing_content, interactive_content)
         permitted_tags     = (option, optgroup)

--- a/emerald/html_templates.nim
+++ b/emerald/html_templates.nim
@@ -258,10 +258,8 @@ proc processNode(writer: PStmtListWriter, context: PContext,
                 else:
                     parsedAttributes.incl("id")
                     processAttribute(writer, "id", child)
-            of nnkDo:
-                for doChild in child.children:
-                    if doChild.kind == nnkStmtList:
-                        nodeChildList = doChild
+            of nnkStmtList:
+              nodeChildList = child
             else:
                 child.quitUnexpected("token", child.kind)
 


### PR DESCRIPTION
Here is a proposed fix for #1. The changes were:
- defer now a keyword
- no longer get nnkDo when not using do-notation: see Araq/nim#1120
- I changed a quit to raise an exception (for line debugging info)
