### PR TITLE
Fix 'table' and 'script' tags

### DIFF
--- a/src/emerald/private/html5.nim
+++ b/src/emerald/private/html5.nim
@@ -286,7 +286,7 @@ tag_list:
     script:
         content_categories = (metadata_content, flow_content, phrasing_content)
         permitted_content  = text_content
-        optional_attrs     = (async, src, `type`, `defer`)
+        optional_attrs     = (async, src, `type`, `defer`, charset)
     select:
         content_categories = (flow_content, phrasing_content,
                               interactive_content)

--- a/src/emerald/private/html5.nim
+++ b/src/emerald/private/html5.nim
@@ -305,7 +305,7 @@ tag_list:
         permitted_content = phrasing_content
     table:
         content_categories = flow_content
-        permitted_tags     = (caption, colgroup, thread, tbody, tfoot, tr)
+        permitted_tags     = (caption, colgroup, thead, tbody, tfoot, tr)
     (tbody, tfoot, thead):
         permitted_tags = tr
     (td, th):


### PR DESCRIPTION
Fixed 'thead' typo in 'table' tag and added 'charset' attribute to 'script' tag.
