### PR TITLE
Add aria-* attributes support

### DIFF
--- a/src/emerald/html.nim
+++ b/src/emerald/html.nim
@@ -517,6 +517,23 @@ proc parse_tag(writer: StmtListWriter, context: ParseContext,
                             newCall(ident("$"),
                             copy_tree_replace_params(context, dataPair[1])))
                 added = true
+            if attrName == "aria":
+                if node[i][1].kind != nnkTableConstr:
+                    quit_invalid(node[i][1],
+                            "value kind for aria (expected table constructor)",
+                            node[i][1].kind)
+                for ariaPair in node[i][1].children:
+                    # this couldn't be a table constructor if this assertion
+                    # fails
+                    assert ariaPair.kind == nnkExprColonExpr
+                    if ariaPair[0].kind != nnkStrLit:
+                        quit_invalid(ariaPair[0],
+                                "key token (expected string literal)",
+                                ariaPair[0].kind)
+                    writer.add_attr_val("aria-" & ariaPair[0].strVal,
+                            newCall(ident("$"),
+                            copy_tree_replace_params(context, ariaPair[1])))
+                added = true
             if not added:
                 if is_bool_attr(attrName):
                     writer.add_bool_attr(attrName, node[i][1])

--- a/src/emerald/private/html5.nim
+++ b/src/emerald/private/html5.nim
@@ -3,7 +3,7 @@ import tagdef
 
 tag_list:
     global:
-        attributes = (accesskey, class, contenteditable, contextmenu, data, dir,
+        attributes = (accesskey, aria, class, contenteditable, contextmenu, data, dir,
                       draggable, dropzone, hidden, id, itemid, itemprop,
                       itemref, itemscope, itemtype, lang, spellcheck, style,
                       tabindex, title,

--- a/src/emerald/private/html5.nim
+++ b/src/emerald/private/html5.nim
@@ -3,10 +3,11 @@ import tagdef
 
 tag_list:
     global:
-        attributes = (accesskey, aria, class, contenteditable, contextmenu, data, dir,
+        attributes = (accesskey, aria, class, contenteditable, contextmenu, 
+                      data, dir,
                       draggable, dropzone, hidden, id, itemid, itemprop,
-                      itemref, itemscope, itemtype, lang, spellcheck, style,
-                      tabindex, title,
+                      itemref, itemscope, itemtype, lang, role, spellcheck, 
+                      style, tabindex, title,
                       onabort, onautocomplete, onautocompleteerror, onblur,
                       oncancel, oncanplay, oncanplaythrough, onchange, onclick,
                       onclose, oncontextmenu, oncuechange, ondblclick, ondrag,


### PR DESCRIPTION
The [ARIA attributes](https://www.w3.org/TR/html-aria/) are meant to increase website accessibility, which are using dash inside attribute name, so we need special treatment (like data-*).

They're often used in [Bootstrap](https://getbootstrap.com) templates.