### PR TITLE
Pass template parameters to mixin

### DIFF
--- a/src/emerald/html.nim
+++ b/src/emerald/html.nim
@@ -776,8 +776,9 @@ proc parse_children(writer: StmtListWriter, context: ParseContext,
                 
                 var mixinCall = newCall(mixinSym, writer.streamName)
                 for i in 1 .. node[1].len - 1:
-                    mixinCall.add(node[1][i])
-                
+                    let replacedParam = copy_tree_replace_params(context,
+                            node[1][i])
+                    mixinCall.add(replacedParam)
                 for s in mixinLevel.call_content_syms:
                     mixinCall.add(newNimNode(nnkLambda).add(newEmptyNode(),
                             newEmptyNode(), newEmptyNode(), newNimNode(


### PR DESCRIPTION
Enables passing template parameters to mixins:
```nim
import emerald
proc mySection(title: string) {.html_mixin.} =
    section:
        h1: title

proc templ(numItems: int) {.html_templ.} =
  append content:
    html(lang="en"):
        body:
            call_mixin mySection($numItems)
```